### PR TITLE
Fix #6 Catch extra errors around users

### DIFF
--- a/main/server/apps/grid.ts
+++ b/main/server/apps/grid.ts
@@ -86,9 +86,10 @@ class Grid extends AAppDataGetters {
             "./en-GB/Phrases/history.sqlite"
           );
 
-          await fs.promises.access(userHistory);
-
-          validDynamicLocations.push(userHistory);
+          try {
+            await fs.promises.access(userHistory);
+            validDynamicLocations.push(userHistory);
+          } catch {}
         }
       } catch {}
     }


### PR DESCRIPTION
Fixes #6 

When we were iterating through the users we werent catching errors at a high enough level.

This meant that when we had a user with no history file we totally halted looking for other users