### PR TITLE
Add support for predictable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 Baton is a simple app that allows AAC software users to upload data for research purposes.
 
 Currently, Baton supports extracting data from:
+
 - Dasher
 - Grid 3
 - Plain text files
 - Tobii Communicator
+- Predictable
 
 We plan to add additional supported apps in the future.
 

--- a/__tests__/Predictable-test-data.json
+++ b/__tests__/Predictable-test-data.json
@@ -1,0 +1,242 @@
+{
+  "RecordedMessages": [
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We You are a number that is was the first place and I Yes Yes yes and ",
+        "SpokenText": "We You are a number that is was the first place and I Yes Yes yes and "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We You are a number that is was ",
+        "SpokenText": "We You are a number that is was "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "No",
+        "SpokenText": "No"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "No",
+        "SpokenText": "No"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": " We were in able the and same with ",
+        "SpokenText": " We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We were in able the and same with ",
+        "SpokenText": "We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We were in able the and same with ",
+        "SpokenText": "We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "The fact of course you are a number ",
+        "SpokenText": "The fact of course you are a number "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "History 2",
+        "SpokenText": "History 2"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "History 1",
+        "SpokenText": "History 1"
+      }
+    }
+  ]
+}

--- a/__tests__/predictable.ts
+++ b/__tests__/predictable.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import PlainText from "../main/server/apps/plain-text";
+import { processPredictableFile } from "../main/server/apps/predictable";
+
+test("reads data grid data from a predictable file", async () => {
+  // Arrange
+  const pathToTestFile = path.join(__dirname, "./Predictable-test-data.json");
+  const predictableDataSource = new PlainText({
+    locations: [pathToTestFile],
+    processFile: processPredictableFile,
+  });
+
+  // Act
+  const phrases = await predictableDataSource.getText();
+
+  // Assert
+  expect(phrases).toBe(
+    `We You are a number that is was the first place and I Yes Yes yes and.
+Yes.
+We You are a number that is was.
+No.
+Yes.
+No.
+Yes.
+We were in able the and same with.
+Yes.
+We were in able the and same with.
+We were in able the and same with.
+The fact of course you are a number.
+History 2.
+History 1.`
+  );
+});

--- a/main/server/apps/index.ts
+++ b/main/server/apps/index.ts
@@ -4,7 +4,7 @@ import { app } from "electron";
 import PlainText from "./plain-text";
 import Grid from "./grid";
 import Communicator from "./communicator";
-import { AAppDataGetters, EPossibleSources } from "./types";
+import { AAppDataGetters, EPossibleSources, PredictableHistory } from "./types";
 import { addEndMarkerToPhrase } from "../lib/add-end-marker-to-phrase";
 
 const DASHER_PATHS = [
@@ -72,6 +72,19 @@ export const appFactory = ({
       });
     case EPossibleSources.Communicator:
       return new Communicator({ location: path });
+    case EPossibleSources.Predictable:
+      return new PlainText({
+        locations: [path],
+        processFile: (buff) => {
+          const parsedBuffer: PredictableHistory = JSON.parse(buff.toString());
+
+          return parsedBuffer.RecordedMessages.map((message) =>
+            addEndMarkerToPhrase(message.Transcription.Text.trim())
+          )
+            .join(" ")
+            .replace(/\.\./g, ".");
+        },
+      });
   }
 
   throw new Error(`${name} not implemented`);

--- a/main/server/apps/index.ts
+++ b/main/server/apps/index.ts
@@ -4,8 +4,9 @@ import { app } from "electron";
 import PlainText from "./plain-text";
 import Grid from "./grid";
 import Communicator from "./communicator";
-import { AAppDataGetters, EPossibleSources, PredictableHistory } from "./types";
+import { AAppDataGetters, EPossibleSources } from "./types";
 import { addEndMarkerToPhrase } from "../lib/add-end-marker-to-phrase";
+import { processPredictableFile } from "./predictable";
 
 const DASHER_PATHS = [
   path.join(__dirname, "../../../test-data/apps/dasher.txt"),
@@ -75,15 +76,7 @@ export const appFactory = ({
     case EPossibleSources.Predictable:
       return new PlainText({
         locations: [path],
-        processFile: (buff) => {
-          const parsedBuffer: PredictableHistory = JSON.parse(buff.toString());
-
-          return parsedBuffer.RecordedMessages.map((message) =>
-            addEndMarkerToPhrase(message.Transcription.Text.trim())
-          )
-            .join(" ")
-            .replace(/\.\./g, ".");
-        },
+        processFile: processPredictableFile,
       });
   }
 

--- a/main/server/apps/predictable.ts
+++ b/main/server/apps/predictable.ts
@@ -1,0 +1,10 @@
+import { addEndMarkerToPhrase } from "../lib/add-end-marker-to-phrase";
+import { PredictableHistory } from "./types";
+
+export const processPredictableFile = (buff: Buffer): string => {
+  const parsedBuffer: PredictableHistory = JSON.parse(buff.toString());
+
+  return parsedBuffer.RecordedMessages.map((message) =>
+    addEndMarkerToPhrase(message.Transcription.Text.trim())
+  ).join("\n");
+};

--- a/main/server/apps/types.ts
+++ b/main/server/apps/types.ts
@@ -4,6 +4,7 @@ export enum EPossibleSources {
   NewlineSeparatedPlainText = "Newline Separated Plain Text",
   Grid = "Grid",
   Communicator = "Tobii Communicator",
+  Predictable = "Predictable",
 }
 export abstract class AAppDataGetters {
   abstract doesExist(): Promise<boolean>;
@@ -12,3 +13,14 @@ export abstract class AAppDataGetters {
   abstract getName(): EPossibleSources;
   abstract getPath(): Promise<string>;
 }
+
+type PredictableRecordedMessage = {
+  FileName: string;
+  Transcription: {
+    Text: string;
+  };
+};
+
+export type PredictableHistory = {
+  RecordedMessages: Array<PredictableRecordedMessage>;
+};

--- a/main/server/index.ts
+++ b/main/server/index.ts
@@ -271,16 +271,19 @@ export const registerIPCHandlers = async (): Promise<void> => {
   );
 
   ipcMain.handle("get-stats", async () => {
-    const [totalSentences, submittedSentences, unviewedSentences] =
-      await Promise.all([
-        sentencesRepo.count(),
-        sentencesRepo.count({
-          where: { submitted: true },
-        }),
-        sentencesRepo.count({
-          where: { viewed: false },
-        }),
-      ]);
+    const [
+      totalSentences,
+      submittedSentences,
+      unviewedSentences,
+    ] = await Promise.all([
+      sentencesRepo.count(),
+      sentencesRepo.count({
+        where: { submitted: true },
+      }),
+      sentencesRepo.count({
+        where: { viewed: false },
+      }),
+    ]);
 
     return { totalSentences, submittedSentences, unviewedSentences };
   });
@@ -356,6 +359,7 @@ export const registerIPCHandlers = async (): Promise<void> => {
       EPossibleSources.PlainText,
       EPossibleSources.NewlineSeparatedPlainText,
       EPossibleSources.Communicator,
+      EPossibleSources.Predictable,
     ];
 
     const apps = await appRepo.find();

--- a/renderer/lib/types.ts
+++ b/renderer/lib/types.ts
@@ -37,4 +37,5 @@ export enum EPossibleSources {
   NewlineSeparatedPlainText = "Newline Separated Plain Text",
   Grid = "Grid",
   Communicator = "Tobii Communicator",
+  Predictable = "Predictable",
 }

--- a/renderer/pages/settings/add-source.tsx
+++ b/renderer/pages/settings/add-source.tsx
@@ -82,11 +82,18 @@ const AddSource = () => {
         EPossibleSources.PlainText,
         EPossibleSources.NewlineSeparatedPlainText,
         EPossibleSources.Communicator,
+        EPossibleSources.Predictable,
       ].includes(selectedSource) && (
         <Grid item container xs={12} alignItems="center" spacing={1}>
           <Grid item>
             <input
-              accept={EPossibleSources.Communicator ? ".phr" : "text/plain"}
+              accept={
+                EPossibleSources.Communicator === selectedSource
+                  ? ".phr"
+                  : EPossibleSources.Predictable === selectedSource
+                  ? ".json"
+                  : "text/plain"
+              }
               type="file"
               style={{ display: "none" }}
               id="file-select"

--- a/test-data/Predictable.json
+++ b/test-data/Predictable.json
@@ -1,0 +1,276 @@
+{
+  "RecordedMessages": [
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Can you help me with this please Can you help me with this please I might need extra time to get my message across I might need extra time to get my message across ",
+        "SpokenText": "Can you help me with this please Can you help me with this please I might need extra time to get my message across I might need extra time to get my message across "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We You are a number that is was the first place and I Yes Yes yes and ",
+        "SpokenText": "We You are a number that is was the first place and I Yes Yes yes and "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We You are a number that is was ",
+        "SpokenText": "We You are a number that is was "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "No",
+        "SpokenText": "No"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "No",
+        "SpokenText": "No"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": " We were in able the and same with ",
+        "SpokenText": " We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "Yes",
+        "SpokenText": "Yes"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We were in able the and same with ",
+        "SpokenText": "We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We have were a a a a is not a to say Sgroi the same fgs",
+        "SpokenText": "We have were a a a a is not a to say Sgroi the same fgs"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "We were in able the and same with ",
+        "SpokenText": "We were in able the and same with "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "The fact of course you are a number ",
+        "SpokenText": "The fact of course you are a number "
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "History 2",
+        "SpokenText": "History 2"
+      }
+    },
+    {
+      "FileName": "",
+      "FileUrl": "",
+      "Tags": [
+        {
+          "Name": "History"
+        }
+      ],
+      "Icon": "icon-history.svg",
+      "IconUrl": "history",
+      "MultimediaType": "",
+      "MultimediaLink": "",
+      "Transcription": {
+        "Text": "History 1",
+        "SpokenText": "History 1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for [predictable](https://therapy-box.co.uk/predictable), requested by @willwade. 

[This video outlines how a user of predictable can access their history](https://www.youtube.com/watch?v=MzSonPxImGg). Once downloaded the user will be give a JSON file of their history. I have included an example in the `test-data` folder.

Support is added by adding a new 'Predictable' type to the `EPossibleSources` type. It is then implemented using the `PlainText` class with a custom `processFile` function to parse the phrases from the JSON file.

I also fixed a bug that was causing the UI to only allow users to upload `.phr` files

CC @kdv123 @codetheweb